### PR TITLE
feat: add standalone C++ dependency checker

### DIFF
--- a/tools/dependency_checker/CMakeLists.txt
+++ b/tools/dependency_checker/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.18)
+project(dependency_checker VERSION 1.0.0)
+
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Only include what we need
+include(FetchContent)
+
+# Define versions
+set(NLOHMANN_JSON_VERSION "3.11.3")
+
+# Find CURL package
+find_package(CURL REQUIRED)
+
+# Fetch JSON library
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v${NLOHMANN_JSON_VERSION}
+)
+
+FetchContent_MakeAvailable(nlohmann_json)
+
+# Create the executable
+add_executable(dependency_checker
+    src/main.cpp
+    src/github_api.cpp
+    src/cmake_parser.cpp
+)
+
+target_link_libraries(dependency_checker PRIVATE
+    CURL::libcurl
+    nlohmann_json::nlohmann_json
+)
+
+install(TARGETS dependency_checker
+    RUNTIME DESTINATION bin
+)

--- a/tools/dependency_checker/README.md
+++ b/tools/dependency_checker/README.md
@@ -1,0 +1,33 @@
+# Dependency Checker
+
+C++ tool to check and update CMake dependency versions.
+
+## Building
+```bash
+mkdir -p build && cd build
+cmake ..
+make
+```
+
+## Usage
+```bash
+./dependency_checker --dependencies-file path/to/dependencies.cmake
+```
+
+## Features
+- Checks GitHub repositories for newer versions of dependencies
+- Supports both direct version tags and version variables in CMake
+- Updates dependencies.cmake file automatically when newer versions are found
+- Maintains existing version prefix style (with or without 'v')
+
+## Example
+```bash
+# Check dependencies in the main project
+./dependency_checker --dependencies-file ../../cmake/dependencies.cmake
+```
+
+## Requirements
+- CMake 3.18 or higher
+- C++ compiler with C++17 support
+- libcurl
+- nlohmann_json

--- a/tools/dependency_checker/build.sh
+++ b/tools/dependency_checker/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir -p build
+cd build
+cmake ..
+make

--- a/tools/dependency_checker/src/cmake_parser.cpp
+++ b/tools/dependency_checker/src/cmake_parser.cpp
@@ -1,0 +1,151 @@
+#include "cmake_parser.hpp"
+#include <regex>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+std::string escape_regex(const std::string& str) {
+    static const std::string special_chars = "[](){}.*+?|^$\\";
+    std::string escaped;
+    for (char c : str) {
+        if (special_chars.find(c) != std::string::npos) {
+            escaped += '\\';
+        }
+        escaped += c;
+    }
+    return escaped;
+}
+
+std::unordered_map<std::string, std::string> CMakeParser::parseVersionVariables(const std::string& content) {
+    std::unordered_map<std::string, std::string> variables;
+    std::regex set_pattern(R"###(set\s*\(\s*([A-Za-z0-9_]+_VERSION)\s*"([^"]+)"\s*\))###");
+
+    std::sregex_iterator begin(content.begin(), content.end(), set_pattern);
+    std::sregex_iterator end;
+
+    for (auto i = begin; i != end; ++i) {
+        std::smatch match = *i;
+        variables[match[1].str()] = match[2].str();
+        std::cout << "Found version variable: " << match[1].str() << " = " << match[2].str() << "\n";
+    }
+
+    return variables;
+}
+
+std::pair<std::vector<Dependency>, std::string> CMakeParser::parseDependencies(const std::filesystem::path& file_path) {
+    std::ifstream file(file_path);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file: " + file_path.string());
+    }
+
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    std::string content = buffer.str();
+
+    std::cout << "File contents:\n" << content << "\n=== END FILE CONTENTS ===\n";
+
+    auto variables = parseVersionVariables(content);
+    std::vector<Dependency> dependencies;
+
+    size_t pos = 0;
+    while ((pos = content.find("FetchContent_Declare", pos)) != std::string::npos) {
+        size_t open_paren = content.find('(', pos);
+        if (open_paren == std::string::npos) break;
+
+        size_t close_paren = open_paren + 1;
+        int paren_count = 1;
+        while (paren_count > 0 && close_paren < content.length()) {
+            if (content[close_paren] == '(') paren_count++;
+            else if (content[close_paren] == ')') paren_count--;
+            close_paren++;
+        }
+
+        if (paren_count > 0) {
+            std::cerr << "Error: Unmatched parentheses in FetchContent_Declare block\n";
+            break;
+        }
+
+        std::string block = content.substr(open_paren + 1, close_paren - open_paren - 2);
+
+        std::regex name_pattern(R"(\s*(\w+)\s*)");
+        std::regex repo_pattern(R"(GIT_REPOSITORY\s+([^\s\n]+))");
+        std::regex tag_pattern(R"(GIT_TAG\s+(?:v?\$\{([\w_]+)\}|v?([^\s\n\)]+)))");
+
+        std::smatch name_match, repo_match, tag_match;
+
+        if (std::regex_search(block, name_match, name_pattern) &&
+            std::regex_search(block, repo_match, repo_pattern) &&
+            std::regex_search(block, tag_match, tag_pattern)) {
+
+            Dependency dep;
+            dep.name = name_match[1].str();
+            dep.repo = std::regex_replace(repo_match[1].str(), std::regex(R"(^"|"$)"), "");
+
+            if (tag_match[1].matched) {
+                std::string var_name = tag_match[1].str();
+                if (variables.count(var_name)) {
+                    dep.variable = var_name;
+                    dep.tag = variables[var_name];
+                    std::cout << "  Resolved variable " << var_name << " to: " << dep.tag << "\n";
+                }
+            } else if (tag_match[2].matched) {
+                dep.tag = tag_match[2].str();
+                dep.variable = "";
+            }
+
+            if (!dep.tag.empty() && block.find("GIT_TAG v") != std::string::npos && dep.tag[0] != 'v') {
+                dep.tag = "v" + dep.tag;
+            }
+
+            if (!dep.name.empty() && !dep.repo.empty() && !dep.tag.empty()) {
+                std::cout << "Found dependency:\n";
+                std::cout << "  Name: " << dep.name << "\n";
+                std::cout << "  Repo: " << dep.repo << "\n";
+                std::cout << "  Tag:  " << dep.tag << "\n";
+                dependencies.push_back(dep);
+            }
+        }
+
+        pos = close_paren;
+    }
+
+    if (dependencies.empty()) {
+        std::cout << "No dependencies found in file.\n";
+    }
+
+    return {dependencies, content};
+}
+
+void CMakeParser::updateFile(const std::string& content, const std::vector<Dependency>& dependencies,
+                           const std::filesystem::path& file_path) {
+    std::string updated_content = content;
+    bool updated = false;
+
+    for (const auto& dep : dependencies) {
+        if (dep.latest_version.empty()) continue;
+
+        if (dep.variable.empty()) {
+            std::regex tag_pattern("GIT_TAG\\s+" + escape_regex(dep.tag));
+            updated_content = std::regex_replace(updated_content, tag_pattern,
+                                              "GIT_TAG " + dep.latest_version);
+        } else {
+            std::string new_version = dep.latest_version;
+            if (new_version[0] == 'v') {
+                new_version = new_version.substr(1);
+            }
+
+            std::regex version_pattern(R"###(set\(\s*)###" + dep.variable + R"###(\s+"[^"]+"\))###");
+            updated_content = std::regex_replace(updated_content, version_pattern,
+                                              "set(" + dep.variable + " \"" + new_version + "\")");
+        }
+        updated = true;
+    }
+
+    if (updated) {
+        std::ofstream file(file_path);
+        if (!file.is_open()) {
+            throw std::runtime_error("Failed to open file for writing: " + file_path.string());
+        }
+        file << updated_content;
+    }
+}

--- a/tools/dependency_checker/src/cmake_parser.hpp
+++ b/tools/dependency_checker/src/cmake_parser.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <filesystem>
+#include <unordered_map>
+#include <optional>
+
+struct Dependency {
+    std::string name;
+    std::string repo;
+    std::string tag;
+    std::string variable;
+    std::string latest_version;
+};
+
+class CMakeParser {
+public:
+    static std::pair<std::vector<Dependency>, std::string> parseDependencies(const std::filesystem::path& file_path);
+    static void updateFile(const std::string& content, const std::vector<Dependency>& dependencies,
+                          const std::filesystem::path& file_path);
+private:
+    static std::unordered_map<std::string, std::string> parseVersionVariables(const std::string& content);
+};

--- a/tools/dependency_checker/src/github_api.cpp
+++ b/tools/dependency_checker/src/github_api.cpp
@@ -1,0 +1,144 @@
+#include "github_api.hpp"
+#include <nlohmann/json.hpp>
+#include <curl/curl.h>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <iostream>
+#include <algorithm>
+#include <cstdlib>
+
+using json = nlohmann::json;
+
+// Callback for CURL to write response data
+static size_t WriteCallback(void* contents, size_t size, size_t nmemb, std::string* userp) {
+    userp->append((char*)contents, size * nmemb);
+    return size * nmemb;
+}
+
+std::pair<std::string, std::string> GitHubAPI::parseGitHubUrl(const std::string& url) {
+    std::regex pattern(R"(github\.com[:/]([^/]+)/([^/\.]+))");
+    std::smatch matches;
+    if (std::regex_search(url, matches, pattern) && matches.size() > 2) {
+        return {matches[1].str(), matches[2].str()};
+    }
+    throw std::runtime_error("Invalid GitHub URL format");
+}
+
+std::string GitHubAPI::makeRequest(const std::string& url) {
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        throw std::runtime_error("Failed to initialize CURL");
+    }
+
+    std::string response_data;
+    struct curl_slist* headers = nullptr;
+
+    // Add GitHub token if available
+    const char* github_token = std::getenv("GITHUB_TOKEN");
+    if (github_token) {
+        std::string auth_header = "Authorization: Bearer " + std::string(github_token);
+        headers = curl_slist_append(headers, auth_header.c_str());
+        std::cout << "Using GitHub token for authentication" << std::endl;
+    } else {
+        std::cout << "Warning: No GitHub token found in environment" << std::endl;
+    }
+
+    headers = curl_slist_append(headers, "Accept: application/vnd.github.v3+json");
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_data);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "Dependency-Checker/1.0");
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+
+    std::cout << "Making request to: " << url << std::endl;
+
+    CURLcode res = curl_easy_perform(curl);
+
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK) {
+        throw std::runtime_error("Failed to make HTTP request: " + std::string(curl_easy_strerror(res)));
+    }
+
+    if (http_code != 200) {
+        throw std::runtime_error("GitHub API request failed with status code: " + std::to_string(http_code));
+    }
+
+    return response_data;
+}
+
+std::vector<int> GitHubAPI::versionToComponents(const std::string& version) {
+    std::vector<int> components;
+    std::string version_str = version;
+    if (version_str[0] == 'v') {
+        version_str = version_str.substr(1);
+    }
+
+    std::regex number_pattern(R"(\d+)");
+    auto numbers_begin = std::sregex_iterator(version_str.begin(), version_str.end(), number_pattern);
+    auto numbers_end = std::sregex_iterator();
+
+    for (std::sregex_iterator i = numbers_begin; i != numbers_end; ++i) {
+        components.push_back(std::stoi(i->str()));
+    }
+
+    return components;
+}
+
+std::optional<std::string> GitHubAPI::getLatestVersion(const std::string& repo_url) {
+    try {
+        auto [owner, repo] = parseGitHubUrl(repo_url);
+        std::string api_url = "https://api.github.com/repos/" + owner + "/" + repo + "/tags";
+
+        std::cout << "Checking latest version for " << owner << "/" << repo << std::endl;
+
+        std::string response = makeRequest(api_url);
+        auto tags = json::parse(response);
+
+        std::cout << "Found " << tags.size() << " tags" << std::endl;
+
+        std::optional<std::string> latest_version;
+        std::vector<int> highest_version;
+
+        for (const auto& tag : tags) {
+            std::string tag_name = tag["name"];
+            std::cout << "Processing tag: " << tag_name;
+
+            if (std::regex_match(tag_name, std::regex(R"(v?\d+\.\d+\.\d+$)"))) {
+                auto version_components = versionToComponents(tag_name);
+                std::cout << " (valid semver)";
+
+                if (latest_version.has_value()) {
+                    auto current_highest = versionToComponents(latest_version.value());
+                    if (version_components > current_highest) {
+                        std::cout << " - new highest version";
+                        latest_version = tag_name;
+                        highest_version = version_components;
+                    }
+                } else {
+                    std::cout << " - first valid version";
+                    latest_version = tag_name;
+                    highest_version = version_components;
+                }
+            }
+            std::cout << std::endl;
+        }
+
+        if (latest_version) {
+            std::cout << "Latest version found: " << latest_version.value() << std::endl;
+        } else {
+            std::cout << "No valid version tags found" << std::endl;
+        }
+
+        return latest_version;
+    } catch (const std::exception& e) {
+        std::cerr << "Error getting latest version: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+}

--- a/tools/dependency_checker/src/github_api.hpp
+++ b/tools/dependency_checker/src/github_api.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <string>
+#include <optional>
+#include <vector>
+#include <utility>
+#include <nlohmann/json.hpp>
+
+class GitHubAPI {
+public:
+    // Get the latest version tag from a GitHub repository
+    static std::optional<std::string> getLatestVersion(const std::string& repo_url);
+
+    // Convert version string to comparable components
+    static std::vector<int> versionToComponents(const std::string& version);
+
+private:
+    // Parse owner and repo from GitHub URL
+    static std::pair<std::string, std::string> parseGitHubUrl(const std::string& url);
+
+    // Make HTTP request to GitHub API
+    static std::string makeRequest(const std::string& url);
+};

--- a/tools/dependency_checker/src/main.cpp
+++ b/tools/dependency_checker/src/main.cpp
@@ -1,0 +1,104 @@
+#include "github_api.hpp"
+#include "cmake_parser.hpp"
+#include <iostream>
+#include <string>
+#include <filesystem>
+#include <vector>
+#include <algorithm>
+
+struct Options {
+    std::string dependencies_file;
+    bool dry_run = false;
+};
+
+void printUsage(const char* program) {
+    std::cout << "Usage: " << program << " --dependencies-file <path/to/dependencies.cmake> [--dry-run]\n"
+              << "Options:\n"
+              << "  --dependencies-file  Path to the dependencies.cmake file\n"
+              << "  --dry-run           Check for updates without modifying the file\n";
+}
+
+Options parseOptions(int argc, char* argv[]) {
+    Options options;
+    std::vector<std::string> args(argv + 1, argv + argc);
+
+    auto it = std::find(args.begin(), args.end(), "--dependencies-file");
+    if (it != args.end() && std::next(it) != args.end()) {
+        options.dependencies_file = *std::next(it);
+    }
+
+    options.dry_run = std::find(args.begin(), args.end(), "--dry-run") != args.end();
+
+    if (options.dependencies_file.empty()) {
+        throw std::runtime_error("Missing required argument: --dependencies-file");
+    }
+
+    return options;
+}
+
+int main(int argc, char* argv[]) {
+    try {
+        auto options = parseOptions(argc, argv);
+
+        if (!std::filesystem::exists(options.dependencies_file)) {
+            std::cerr << "File not found: " << options.dependencies_file << std::endl;
+            return 1;
+        }
+
+        std::cout << "Checking for updates...\n";
+        if (options.dry_run) {
+            std::cout << "Running in dry-run mode - no files will be modified\n";
+        }
+
+        // Parse dependencies file
+        auto [dependencies, content] = CMakeParser::parseDependencies(options.dependencies_file);
+        if (dependencies.empty()) {
+            std::cout << "No dependencies found in the specified file.\n";
+            return 0;
+        }
+
+        // Check each dependency for updates
+        bool updates_available = false;
+        for (auto& dep : dependencies) {
+            std::cout << "Checking " << dep.name << " (" << dep.repo << ")...\n";
+
+            auto latest_version = GitHubAPI::getLatestVersion(dep.repo);
+            if (!latest_version) {
+                std::cout << "  Could not determine the latest version for " << dep.name
+                         << " (current version: " << dep.tag << ")\n";
+                continue;
+            }
+
+            dep.latest_version = *latest_version;
+            auto current = GitHubAPI::versionToComponents(dep.tag);
+            auto latest = GitHubAPI::versionToComponents(*latest_version);
+
+            if (latest > current) {
+                std::cout << "  Update available for " << dep.name << ": "
+                         << *latest_version << " (current: " << dep.tag << ")\n";
+                updates_available = true;
+            } else {
+                std::cout << "  " << dep.name << " is up-to-date (current version: "
+                         << dep.tag << ")\n";
+            }
+        }
+
+        // Update the file if needed and not in dry-run mode
+        if (updates_available) {
+            if (!options.dry_run) {
+                CMakeParser::updateFile(content, dependencies, options.dependencies_file);
+                std::cout << "File updated successfully.\n";
+            } else {
+                std::cout << "Updates available but no changes made (dry-run mode).\n";
+            }
+        } else {
+            std::cout << "No updates were made.\n";
+        }
+
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        printUsage(argv[0]);
+        return 1;
+    }
+}


### PR DESCRIPTION
Convert Python dependency checker to standalone C++ tool

- Converted Python script to C++ implementation
- Made tool buildable independently of main project
- Added separate CMake configuration
- Tested locally with existing dependencies.cmake

Link to Devin run: https://app.devin.ai/sessions/7b50c8d905a941dba9336b4adf83b55b